### PR TITLE
fix(deploy-dag): correct slack notification and project folder copy into nested folder

### DIFF
--- a/src/jobs/deploy-dag-legacy.yml
+++ b/src/jobs/deploy-dag-legacy.yml
@@ -3,10 +3,10 @@ description: Deploy a legacy Airflow DAG to Host with rSync and SSH
 parameters:
   executor-repo:
     type: string
-    default: circleci/python
+    default: goodwaygroup/circleci-build-images
   executor-tag:
     type: string
-    default: "3.7"
+    default: "eks-latest"
   destination-path:
     type: string
   pre-deploy-steps:

--- a/src/jobs/deploy-dag-legacy.yml
+++ b/src/jobs/deploy-dag-legacy.yml
@@ -52,7 +52,7 @@ steps:
       command: |
         eval $(ssh-agent)
         ssh-add ~/.ssh/bot-circleci
-        rsync -avce "ssh -o StrictHostKeyChecking=no -A -J jump" ~/repo airflow:<< parameters.destination-path >> --delete --exclude '*.pyc'
+        rsync -avce "ssh -o StrictHostKeyChecking=no -A -J jump" ~/repo/ airflow:<< parameters.destination-path >> --delete --exclude '*.pyc'
 
   - steps: << parameters.post-deploy-steps >>
 

--- a/src/jobs/deploy-dag-legacy.yml
+++ b/src/jobs/deploy-dag-legacy.yml
@@ -52,7 +52,7 @@ steps:
       command: |
         eval $(ssh-agent)
         ssh-add ~/.ssh/bot-circleci
-        rsync -avce "ssh -o StrictHostKeyChecking=no -A -J jump" ~/repo/ airflow:<< parameters.destination-path >> --delete --exclude '*.pyc'
+        rsync -avce "ssh -o StrictHostKeyChecking=no -A -J jump" ~/repo/ airflow:<< parameters.destination-path >> --delete-excluded --exclude '*.pyc'
 
   - steps: << parameters.post-deploy-steps >>
 


### PR DESCRIPTION
* set default executor to support slack notification
* add a trailing slash to not transmit within folder
* delete files on the remote system that are excluded