### PR TITLE
fix(determine-docker-tag): remove @ from tag and branch name

### DIFF
--- a/src/commands/determine-docker-tag.yml
+++ b/src/commands/determine-docker-tag.yml
@@ -9,6 +9,6 @@ steps:
       name: 'Determine Docker Tag'
       command: |
         SHORT_SHA1=$(git rev-parse --short ${CIRCLE_SHA1})
-        DOCKER_TAG=$([[ ! -z "${CIRCLE_TAG}" ]] && echo ${CIRCLE_TAG//\//-}.${SHORT_SHA1} || ([[ ! -z "${CIRCLE_BRANCH}" ]] && echo ${CIRCLE_BRANCH//\//-}.${SHORT_SHA1} || echo ${SHORT_SHA1}))
+        DOCKER_TAG=$([[ ! -z "${CIRCLE_TAG}" ]] && echo ${CIRCLE_TAG//[\/|@]/-}.${SHORT_SHA1} || ([[ ! -z "${CIRCLE_BRANCH}" ]] && echo ${CIRCLE_BRANCH//[\/|@]/-}.${SHORT_SHA1} || echo ${SHORT_SHA1}))
         echo "export <<parameters.variable>>=${DOCKER_TAG}" >> ${BASH_ENV}
         cat ${BASH_ENV}


### PR DESCRIPTION
Removes the `@` character from the docker tag that is generated

Before (this breaks the build):
![special-char](https://user-images.githubusercontent.com/1429775/105217120-1506a880-5b19-11eb-9374-d90b5a9523e8.png)

After:
![char-removed](https://user-images.githubusercontent.com/1429775/105217172-25b71e80-5b19-11eb-927b-8364077ec67f.png)

This will fix the following build issues:
https://app.circleci.com/pipelines/github/GoodwayGroup/service-login/27/workflows/207e5327-ddc6-46b7-9774-776f454256ad/jobs/323
https://app.circleci.com/pipelines/github/GoodwayGroup/service-book/241/workflows/b3be1523-16bc-4f60-9bfc-8f49cbf4c588/jobs/608