### PR TITLE
feat(node lint): add npm run lint step to the test-nodejs task

### DIFF
--- a/src/jobs/test-nodejs.yml
+++ b/src/jobs/test-nodejs.yml
@@ -14,8 +14,19 @@ parameters:
     type: steps
     default:
       - run: npm test
+  lint:
+    default: true
+    description: |
+      Lint codebase before test
+    type: boolean
+  lint-steps:
+    type: steps
+    default:
+      - run: npm run lint
+    description: |
+      Steps to run to lint a codebase
 
-executor: 
+executor:
   name: build-images
   tag: << parameters.executor-tag >>
 
@@ -37,11 +48,15 @@ steps:
         - node_modules
       key: << parameters.cache-key >>-{{ checksum "package-lock.json" }}
 
+  - when:
+      condition: <<parameters.lint>>
+      steps: <<parameters.lint-steps>>
+
   - steps: << parameters.test-steps >>
 
-  - when: 
+  - when:
       condition: << parameters.coveralls-upload >>
-      steps: 
+      steps:
         - coveralls/upload
 
   - store_artifacts:


### PR DESCRIPTION
Saw a PR come through that was passing CI even though there were issues that `eslint` should have caught. Discovered that the orb was not running the lint command.

Added this as a feature as it isn't really a fix, but rather an extension.