### PR TITLE
feat: MS-3 Update apollo-service-task

### DIFF
--- a/src/commands/apollo-service-task.yml
+++ b/src/commands/apollo-service-task.yml
@@ -1,4 +1,4 @@
-description: Runs Apollo service cli task
+description: Run Apollo service cli task
 
 parameters:
   task:

--- a/src/commands/apollo-service-task.yml
+++ b/src/commands/apollo-service-task.yml
@@ -14,6 +14,9 @@ parameters:
   graph-name:
     type: string
     default: service-gateway-qoinz
+  is-subgraph:
+    type: boolean
+    default: true
 
 steps:
   - run:
@@ -37,9 +40,25 @@ steps:
       name: Generate schema dump
       command: npm run dump:schema
 
-  - run:
-      name: apollo federation:<< parameters.task >>
-      command: |
-        cat tmp/schema.graphql | \
-        APOLLO_KEY=$APOLLO_FEDERATION_KEY \
-        rover subgraph << parameters.task >> << parameters.graph-name >>@<< parameters.environment >> --name << parameters.app-name >> --schema -
+  - when:
+      condition:
+        equal: [<< parameters.is-subgraph >>, true]
+      steps:
+        - run:
+            name: apollo federation:<< parameters.task >>
+            command: |
+              cat tmp/schema.graphql | \
+              APOLLO_KEY=$APOLLO_FEDERATION_KEY \
+              rover subgraph << parameters.task >> << parameters.graph-name >>@<< parameters.environment >> --name << parameters.app-name >> --schema -
+
+  - when:
+      - not:
+        condition:
+          equal: [<< parameters.is-subgraph >>, false]
+        steps:
+          - run:
+              name: apollo service:<< parameters.task >>
+              command: |
+                cat tmp/schema.graphql | \
+                APOLLO_KEY=$APOLLO_KEY \
+                rover graph << parameters.task >> << parameters.app-name >>@<< parameters.environment >> --schema -

--- a/src/commands/apollo-service-task.yml
+++ b/src/commands/apollo-service-task.yml
@@ -52,13 +52,12 @@ steps:
               rover subgraph << parameters.task >> << parameters.graph-name >>@<< parameters.environment >> --name << parameters.app-name >> --schema -
 
   - when:
-      - not:
-        condition:
-          equal: [<< parameters.is-subgraph >>, false]
-        steps:
-          - run:
-              name: apollo service:<< parameters.task >>
-              command: |
-                cat tmp/schema.graphql | \
-                APOLLO_KEY=$APOLLO_KEY \
-                rover graph << parameters.task >> << parameters.app-name >>@<< parameters.environment >> --schema -
+      condition:
+        equal: [<< parameters.is-subgraph >>, false]
+      steps:
+        - run:
+            name: apollo service:<< parameters.task >>
+            command: |
+              cat tmp/schema.graphql | \
+              APOLLO_KEY=$APOLLO_KEY \
+              rover graph << parameters.task >> << parameters.app-name >>@<< parameters.environment >> --schema -

--- a/src/jobs/apollo-service-task-ecr.yml
+++ b/src/jobs/apollo-service-task-ecr.yml
@@ -20,6 +20,9 @@ parameters:
   graph-name:
     type: string
     default: service-gateway-qoinz
+  is-subgraph:
+    type: boolean
+    default: true
 
 executor:
   name: << parameters.executor-name >>
@@ -32,3 +35,5 @@ steps:
       app-name: << parameters.app-name >>
       environment: << parameters.environment >>
       graph-name: << parameters.graph-name >>
+      is-subgraph: << parameters.is-subgraph >>
+

--- a/src/jobs/apollo-service-task.yml
+++ b/src/jobs/apollo-service-task.yml
@@ -20,6 +20,9 @@ parameters:
   graph-name:
     type: string
     default: service-gateway-qoinz
+  is-subgraph:
+    type: boolean
+    default: true
 
 executor:
   name: << parameters.executor-name >>
@@ -32,3 +35,4 @@ steps:
       app-name: << parameters.app-name >>
       environment: << parameters.environment >>
       graph-name: << parameters.graph-name >>
+      is-subgraph: << parameters.is-subgraph >>

--- a/src/jobs/apollo-service-task.yml
+++ b/src/jobs/apollo-service-task.yml
@@ -3,7 +3,7 @@ description: Run Apollo service cli task
 parameters:
   executor-name:
     type: enum
-    default: 'ecr-authed'
+    default: 'build-images'
     enum: ['build-images', 'dockerhub-authed', 'ecr-authed']
   executor-tag:
     type: string


### PR DESCRIPTION
This PR adds a conditional where apollo-service-task will run a command based on whether is-subgraph is set to true or false. If true, it will run the command to push to a subgraph under Service Gateway. Otherwise, it will push to a standalone graph with the same name as app-name. It will default to pushing to Service Gateway.

This PR also adds an apollo-service-task that uses Dockerhub instead of ECR so that we can use this job in the generator.

I tested this out with the following services:
- Service Pixel QA (both without passing any variable in and with passing is-subgraph in as true)
https://github.com/GoodwayGroup/service-pixel-qa/blob/main/.circleci/config.yml
- Service Invoice (passing is-subgraph in as false)
https://github.com/GoodwayGroup/service-invoice/pull/49