### PR TITLE
feat: enabling docker layer caching on docker-build command

### DIFF
--- a/src/commands/docker-build.yml
+++ b/src/commands/docker-build.yml
@@ -23,10 +23,14 @@ parameters:
   pre-push-steps:
     type: steps
     default: []
+  use-docker-layer-caching:
+    type: boolean
+    default: true
 
 steps:
   - checkout
-  - setup_remote_docker
+  - setup_remote_docker:
+      docker_layer_caching: << parameters.use-docker-layer-caching >>
 
   - when:
       condition:

--- a/src/jobs/docker-build-ecr.yml
+++ b/src/jobs/docker-build-ecr.yml
@@ -30,6 +30,9 @@ parameters:
   pre-push-steps:
     type: steps
     default: []
+  use-docker-layer-caching:
+    type: boolean
+    default: true
 
 executor:
   name: << parameters.executor-name >>
@@ -44,3 +47,4 @@ steps:
       push: << parameters.push >>
       pre-build-steps: << parameters.pre-build-steps >>
       pre-push-steps: << parameters.pre-push-steps >>
+      use-docker-layer-caching: << parameters.use-docker-layer-caching >>

--- a/src/jobs/docker-build.yml
+++ b/src/jobs/docker-build.yml
@@ -30,6 +30,9 @@ parameters:
   pre-push-steps:
     type: steps
     default: []
+  use-docker-layer-caching:
+    type: boolean
+    default: true
 
 executor:
   name: << parameters.executor-name >>
@@ -44,3 +47,4 @@ steps:
       push: << parameters.push >>
       pre-build-steps: << parameters.pre-build-steps >>
       pre-push-steps: << parameters.pre-push-steps >>
+      use-docker-layer-caching: << parameters.use-docker-layer-caching >>


### PR DESCRIPTION
Turning on docker layer cache (by default) for the docker-build command and jobs.

If there are no changes to package.json and package-lock files then the docker build step can be drastically reduced. 

![2023-05-24_17-22-27](https://github.com/GoodwayGroup/circleci-orb/assets/22306490/ad870499-493a-4b7b-a72a-99ebf4cb66e0)

![2023-05-24_17-28-29](https://github.com/GoodwayGroup/circleci-orb/assets/22306490/1deff8b2-2fbf-47f6-afc6-3f33aec6da46)

CircleCI Build Link:
https://app.circleci.com/pipelines/github/GoodwayGroup/service-rmn-product-manager?branch=staging%2FSDG-16-docker-layer-caching

service-rmn-product-manager:
https://github.com/GoodwayGroup/service-rmn-product-manager/compare/staging/SDG-16-docker-layer-caching?expand=1