### PR TITLE
feat: Adds conditional logic for remote docker in tests

### DIFF
--- a/src/commands/test-nodejs.yml
+++ b/src/commands/test-nodejs.yml
@@ -32,10 +32,19 @@ parameters:
     default: true
     description: |
       If enabled, tars the ./coveage directory into coverage.tar for storage.
+  use-remote-docker:
+    type: boolean
+    default: false
+    description: |
+      If enabled, uses the remote docker executor instead of the machine executor.
 
 steps:
   - checkout
-  - setup_remote_docker
+
+  - when:
+      condition: <<parameters.use-remote-docker>>
+      steps:
+        - setup_remote_docker
 
   # Download and cache dependencies
   - restore_cache:

--- a/src/jobs/test-nodejs-ecr.yml
+++ b/src/jobs/test-nodejs-ecr.yml
@@ -50,6 +50,11 @@ parameters:
     default: true
     description: |
       If enabled, tars the ./coveage directory into coverage.tar for storage.
+  use-remote-docker:
+    type: boolean
+    default: false
+    description: |
+      If enabled, uses the remote docker executor instead of the machine executor.
 
 executor:
   name: << parameters.executor-name >>
@@ -65,3 +70,4 @@ steps:
       lint-steps: << parameters.lint-steps >>
       store-coverage-artifacts: << parameters.store-coverage-artifacts >>
       tar-coverage-artifacts: << parameters.tar-coverage-artifacts >>
+      use-remote-docker: << parameters.use-remote-docker >>

--- a/src/jobs/test-nodejs.yml
+++ b/src/jobs/test-nodejs.yml
@@ -51,6 +51,11 @@ parameters:
     default: true
     description: |
       If enabled, tars the ./coveage directory into coverage.tar for storage.
+  use-remote-docker:
+    type: boolean
+    default: false
+    description: |
+      If enabled, uses the remote docker executor instead of the machine executor.
 
 executor:
   name: << parameters.executor-name >>
@@ -64,3 +69,6 @@ steps:
       test-steps: << parameters.test-steps >>
       lint: << parameters.lint >>
       lint-steps: << parameters.lint-steps >>
+      store-coverage-artifacts: << parameters.store-coverage-artifacts >>
+      tar-coverage-artifacts: << parameters.tar-coverage-artifacts >>
+      use-remote-docker: << parameters.use-remote-docker >>


### PR DESCRIPTION
## Description

Updated the test commands to have a new flag for when it should use the setup_remote_docker. By default, this is disabled as in most cases it is not necessary.