### PR TITLE
fix: adding the --force npm flag to overcome version conflicts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             - v0-dependencies-{{ checksum "package-lock.json" }}
       - run:
           name: Dependency Install
-          command: npm install
+          command: npm install --force --no-save
       - save_cache:
           paths:
             - node_modules


### PR DESCRIPTION
Adding the --force npm flag to overcome version conflicts and adding --no-save to it doesn't save the package lock file again.