### PR TITLE
ci: increase footer max line length

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,4 @@
 module.exports = {
     extends: ['@commitlint/config-conventional'],
+    rules: {'footer-max-line-length': [2, 'always', 500] },
 };


### PR DESCRIPTION
### CHANGE TYPE
CI/Chore

### SUMMARY
re: [CircleCI error](https://app.circleci.com/pipelines/github/GoodwayGroup/circleci-orb/233/workflows/4cb06a4a-397a-4f7f-9979-bdf1ae6240fb/jobs/431)
![image (3)](https://github.com/GoodwayGroup/circleci-orb/assets/25352011/eb8f226c-fdde-4183-a92f-e69f7430ee13)
Error fails on the footer-max-length. Increasing the Changelog from 100 to 500 characters.

#### TICKET NUMBER and LINK
N/A

#### TESTING COMPLETED PRIOR TO PR
SSH'd within CircleCI and successfully confirmed a line length of 500 characters
![image (4)](https://github.com/GoodwayGroup/circleci-orb/assets/25352011/92df5642-de67-4cf1-8333-8f148bb57c6d)
