### PR TITLE
feat(args-and-tags): add extra build args and retag build

### DIFF
--- a/src/commands/docker-build.yml
+++ b/src/commands/docker-build.yml
@@ -39,21 +39,21 @@ steps:
   - setup_remote_docker:
       docker_layer_caching: << parameters.use-docker-layer-caching >>
 
-#  - when:
-#      condition:
-#        equal: ["ecr", << parameters.registry-type >>]
-#      steps:
-#        - aws-ecr/ecr-login:
-#            account-url: << parameters.registry-url >>
-#            region: AWS_REGION
-#
-#  - when:
-#      condition:
-#        equal: ["dockerhub", << parameters.registry-type >>]
-#      steps:
-#        - docker/check:
-#            docker-password: DOCKER_PASS
-#            docker-username: DOCKER_USER
+  - when:
+      condition:
+        equal: ["ecr", << parameters.registry-type >>]
+      steps:
+        - aws-ecr/ecr-login:
+            account-url: << parameters.registry-url >>
+            region: AWS_REGION
+
+  - when:
+      condition:
+        equal: ["dockerhub", << parameters.registry-type >>]
+      steps:
+        - docker/check:
+            docker-password: DOCKER_PASS
+            docker-username: DOCKER_USER
 
   - determine-docker-tag
 

--- a/src/commands/docker-build.yml
+++ b/src/commands/docker-build.yml
@@ -32,6 +32,7 @@ parameters:
   additional-tags:
     type: string
     default: ""
+    description: Space separated names for additional images tags.
 
 steps:
   - checkout

--- a/src/commands/docker-build.yml
+++ b/src/commands/docker-build.yml
@@ -29,6 +29,9 @@ parameters:
   extra-build-args:
     default: '--build-arg ssh_prv_key="$(cat ~/.ssh/id_rsa)"'
     type: string
+  additional-tags:
+    type: string
+    default: ""
 
 steps:
   - checkout
@@ -60,6 +63,17 @@ steps:
       tag-env: DOCKER_TAG
       extra_build_args: << parameters.extra-build-args >>
       registry: ${<< parameters.registry-url >>}
+
+  - when:
+      condition: << parameters.additional-tags >>
+      steps:
+        - run:
+            name: Re-tag dynamic docker build with additional tags
+            command: |
+              for i in << parameters.additional-tags >>; do
+                docker tag ${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:${DOCKER_TAG} \
+                ${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:$i
+              done
 
   - when:
       condition: << parameters.push >>

--- a/src/commands/docker-build.yml
+++ b/src/commands/docker-build.yml
@@ -26,6 +26,9 @@ parameters:
   use-docker-layer-caching:
     type: boolean
     default: true
+  extra-build-args:
+    default: '--build-arg ssh_prv_key="$(cat ~/.ssh/id_rsa)"'
+    type: string
 
 steps:
   - checkout
@@ -55,7 +58,7 @@ steps:
   - build-with-dynamic-tag:
       image: ${<< parameters.image-namespace >>}/${<< parameters.image-repo >>}
       tag-env: DOCKER_TAG
-      extra_build_args: '--build-arg ssh_prv_key="$(cat ~/.ssh/id_rsa)"'
+      extra_build_args: << parameters.extra-build-args >>
       registry: ${<< parameters.registry-url >>}
 
   - when:

--- a/src/commands/docker-build.yml
+++ b/src/commands/docker-build.yml
@@ -38,21 +38,21 @@ steps:
   - setup_remote_docker:
       docker_layer_caching: << parameters.use-docker-layer-caching >>
 
-  - when:
-      condition:
-        equal: ["ecr", << parameters.registry-type >>]
-      steps:
-        - aws-ecr/ecr-login:
-            account-url: << parameters.registry-url >>
-            region: AWS_REGION
-
-  - when:
-      condition:
-        equal: ["dockerhub", << parameters.registry-type >>]
-      steps:
-        - docker/check:
-            docker-password: DOCKER_PASS
-            docker-username: DOCKER_USER
+#  - when:
+#      condition:
+#        equal: ["ecr", << parameters.registry-type >>]
+#      steps:
+#        - aws-ecr/ecr-login:
+#            account-url: << parameters.registry-url >>
+#            region: AWS_REGION
+#
+#  - when:
+#      condition:
+#        equal: ["dockerhub", << parameters.registry-type >>]
+#      steps:
+#        - docker/check:
+#            docker-password: DOCKER_PASS
+#            docker-username: DOCKER_USER
 
   - determine-docker-tag
 

--- a/src/commands/push-with-dynamic-tag.yml
+++ b/src/commands/push-with-dynamic-tag.yml
@@ -20,5 +20,5 @@ steps:
   - deploy:
       command: >
         docker push <<parameters.registry>>/<<
-        parameters.image>>:${<<parameters.tag-env>>}
+        parameters.image>> --all-tags
       name: <<parameters.step-name>>

--- a/src/jobs/docker-build-ecr.yml
+++ b/src/jobs/docker-build-ecr.yml
@@ -45,6 +45,9 @@ parameters:
   use-docker-layer-caching:
     type: boolean
     default: true
+  extra-build-args:
+    default: '--build-arg ssh_prv_key="$(cat ~/.ssh/id_rsa)"'
+    type: string
 
 executor:
   name: << parameters.executor-name >>
@@ -61,3 +64,4 @@ steps:
       pre-build-steps: << parameters.pre-build-steps >>
       pre-push-steps: << parameters.pre-push-steps >>
       use-docker-layer-caching: << parameters.use-docker-layer-caching >>
+      extra-build-args: << parameters.extra-build-args >>

--- a/src/jobs/docker-build-ecr.yml
+++ b/src/jobs/docker-build-ecr.yml
@@ -48,6 +48,9 @@ parameters:
   extra-build-args:
     default: '--build-arg ssh_prv_key="$(cat ~/.ssh/id_rsa)"'
     type: string
+  additional-tags:
+    type: string
+    default: ""
 
 executor:
   name: << parameters.executor-name >>
@@ -65,3 +68,4 @@ steps:
       pre-push-steps: << parameters.pre-push-steps >>
       use-docker-layer-caching: << parameters.use-docker-layer-caching >>
       extra-build-args: << parameters.extra-build-args >>
+      additional-tags: << parameters.additional-tags >>

--- a/src/jobs/docker-build.yml
+++ b/src/jobs/docker-build.yml
@@ -45,6 +45,9 @@ parameters:
   use-docker-layer-caching:
     type: boolean
     default: true
+  extra-build-args:
+    default: '--build-arg ssh_prv_key="$(cat ~/.ssh/id_rsa)"'
+    type: string
 
 executor:
   name: << parameters.executor-name >>
@@ -61,3 +64,4 @@ steps:
       pre-build-steps: << parameters.pre-build-steps >>
       pre-push-steps: << parameters.pre-push-steps >>
       use-docker-layer-caching: << parameters.use-docker-layer-caching >>
+      extra-build-args: << parameters.extra-build-args >>

--- a/src/jobs/docker-build.yml
+++ b/src/jobs/docker-build.yml
@@ -48,6 +48,9 @@ parameters:
   extra-build-args:
     default: '--build-arg ssh_prv_key="$(cat ~/.ssh/id_rsa)"'
     type: string
+  additional-tags:
+    type: string
+    default: ""
 
 executor:
   name: << parameters.executor-name >>
@@ -65,3 +68,4 @@ steps:
       pre-push-steps: << parameters.pre-push-steps >>
       use-docker-layer-caching: << parameters.use-docker-layer-caching >>
       extra-build-args: << parameters.extra-build-args >>
+      additional-tags: << parameters.additional-tags >>

--- a/src/jobs/docker-build.yml
+++ b/src/jobs/docker-build.yml
@@ -51,6 +51,7 @@ parameters:
   additional-tags:
     type: string
     default: ""
+    description: Space separated names for additional images tags.
 
 executor:
   name: << parameters.executor-name >>


### PR DESCRIPTION
### SUMMARY
- Allows for additional build args on container build
- In addition to the dynamic tag that's created, any additional tags can be passed in `additional-tags` as space-separated string 

#### TICKET NUMBER and LINK
https://goodwaygroup.atlassian.net/browse/DS-2152

#### TESTING COMPLETED PRIOR TO PR
Confirmed the "Retag..." step runs only when `additional-tags` arg is passed [here](https://app.circleci.com/pipelines/github/GoodwayGroup/ds-bidrange-model/623/workflows/d6563268-1fa9-4888-8e52-a2fd2c6bdd60/jobs/1102) and doesn't run when not passed [here](https://app.circleci.com/pipelines/github/GoodwayGroup/ds-bidrange-model/622/workflows/7498a6bc-30ba-42a9-a156-4d29db311363/jobs/1101)
<img width="969" alt="image" src="https://github.com/GoodwayGroup/circleci-orb/assets/25352011/f6dc81f2-6805-4064-828e-1d07ad4a5de1">

Confirmed `extra-build-args`
<img width="950" alt="image" src="https://github.com/GoodwayGroup/circleci-orb/assets/25352011/31a6dfe2-659e-431b-96b0-8dccdd245443">
