### PR TITLE
ci: override with params

### DIFF
--- a/src/commands/docker-build.yml
+++ b/src/commands/docker-build.yml
@@ -72,8 +72,8 @@ steps:
             name: Re-tag dynamic docker build with additional tags
             command: |
               for i in << parameters.additional-tags >>; do
-                docker tag ${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:${DOCKER_TAG} \
-                ${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/${CIRCLE_PROJECT_REPONAME}:$i
+                docker tag ${<< parameters.registry-url >>}/${<< parameters.image-namespace >>}/${<< parameters.image-repo >>}:${DOCKER_TAG} \
+                ${<< parameters.registry-url >>}/${<< parameters.image-namespace >>}/${<< parameters.image-repo >>}:$i
               done
 
   - when:


### PR DESCRIPTION
Update the retag to the env variable arguments passed from the job as opposed to hardcoded env variables