### PR TITLE
chore: python test coveralls

### DIFF
--- a/src/commands/test-python.yml
+++ b/src/commands/test-python.yml
@@ -11,7 +11,7 @@ parameters:
     default:
       - run:
           name: Push to Coveralls
-          command: coveralls/upload
+          command: poetry run poe coveralls
     description: |
       Steps to run to send Coveralls report for a codebase
     type: steps

--- a/src/jobs/test-python.yml
+++ b/src/jobs/test-python.yml
@@ -14,7 +14,7 @@ parameters:
     default:
       - run:
           name: Push to Coveralls
-          command: coveralls/upload
+          command: poetry run poe coveralls
     description: |
       Steps to run to send Coveralls report for a codebase
     type: steps


### PR DESCRIPTION
### SUMMARY
The `coveralls/upload` command uses npm and is suitable for a cimg/node image. Our test-python job/command runs in cimg/python and therefore, npm is not on the image. 

This change uses poetry to push to coveralls instead.

