### PR TITLE
feat: adding deploy-with-kustomize job & command

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,9 +7,10 @@ display:
   source_url: https://github.com/GoodwayGroup/circleci-orbs
 
 orbs:
-  docker: circleci/docker@1.2.1
-  aws-ecr: circleci/aws-ecr@6.11.0
   aws-cli: circleci/aws-cli@3.1
+  aws-ecr: circleci/aws-ecr@6.11.0
   aws-eks: circleci/aws-eks@2.2.0
   coveralls: coveralls/coveralls@1.0.6
+  docker: circleci/docker@1.2.1
   kubernetes: circleci/kubernetes@1.3.1
+  slack: circleci/slack@4.13.2

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,7 @@ display:
 orbs:
   docker: circleci/docker@1.2.1
   aws-ecr: circleci/aws-ecr@6.11.0
+  aws-cli: circleci/aws-cli@3.1
+  aws-eks: circleci/aws-eks@2.2.0
   coveralls: coveralls/coveralls@1.0.6
+  kubernetes: circleci/kubernetes@1.3.1

--- a/src/commands/deploy-with-kustomize.yml
+++ b/src/commands/deploy-with-kustomize.yml
@@ -1,0 +1,97 @@
+description: Deploy an image to kubernetes via kustomize
+
+parameters:
+  # kube-path:
+  #   type: string
+  #   default: .kube/
+  # environment:
+  #   type: string
+  # notification-channel:
+  #   type: string
+  #   default:
+  # app-name:
+  #   type: string
+  wait-for-rollout:
+    type: boolean
+    default: true
+  post-deploy-steps:
+    type: steps
+    default: []
+  cluster-name:
+    type: string
+  image-name:
+    type: string
+  kustomize-path:
+    type: string
+  namespace:
+    type: string
+  deployment-resource-name:
+    default: deployment/app
+    type: string
+
+steps:
+  - checkout
+  - determine-docker-tag
+
+  - aws-cli/setup:
+      role-arn: $IAM_ROLE_ARN
+      aws-region: AWS_REGION
+  - run:
+      name: 'Install Kustomize'
+      command: |
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+        sudo mv kustomize /usr/local/bin
+
+  - run:
+      name: 'Build Deployment Manifest'
+      command: |
+        cd <<parameters.kustomize-path>>
+        kustomize edit set image <<parameters.image-name>>:$DOCKER_TAG
+        kustomize build . > deploy-manifest.yaml
+        cd
+  - aws-eks/update-kubeconfig-with-authenticator:
+      cluster-name: << parameters.cluster-name >>
+      install-aws-cli: false
+      install-kubectl: true
+      aws-region: $AWS_REGION
+
+  # Deploy
+  # - run:
+  #     name: Deploy configuration to Kubernetes
+  #     command: ${HOME}/kube-apply.sh << parameters.kube-path >><< parameters.environment >> << parameters.app-name >>-<< parameters.environment >>
+
+  # # Conditionally wait for rollout to complete
+  # - when:
+  #     condition: << parameters.wait-for-rollout >>
+  #     steps:
+  #       - monitor-deployment:
+  #           maxAttempts: 30
+  #           kubernetesNamespace: << parameters.app-name >>-<< parameters.environment >>
+  #           kubernetesDeployment: << parameters.app-name >>-<< parameters.environment >>
+
+
+  # Conditionally wait for rollout to complete
+  - when:
+      condition:
+        equal: [<< parameters.wait-for-rollout >>, true]
+      steps:
+        - kubernetes/create-or-update-resource:
+            namespace: << parameters.namespace >>
+            get-rollout-status: true
+            watch-rollout-status: true
+            resource-file-path: <<parameters.kustomize-path>>/deploy-manifest.yaml
+            resource-name: <<parameters.deployment-resource-name>> # Name of the deployment to be used for tracking rollout status
+
+  - when:
+      condition:
+        equal: [<< parameters.wait-for-rollout >>, false]
+      steps:
+        - kubernetes/create-or-update-resource:
+            namespace: << parameters.namespace >>
+            get-rollout-status: true
+            watch-rollout-status: false
+            resource-file-path: <<parameters.kustomize-path>>/deploy-manifest.yaml
+            resource-name: <<parameters.deployment-resource-name>> # Name of the deployment to be used for tracking rollout status
+
+  - steps: << parameters.post-deploy-steps >>
+

--- a/src/commands/deploy-with-kustomize.yml
+++ b/src/commands/deploy-with-kustomize.yml
@@ -1,16 +1,6 @@
 description: Deploy an image to kubernetes via kustomize
 
 parameters:
-  # kube-path:
-  #   type: string
-  #   default: .kube/
-  # environment:
-  #   type: string
-  # notification-channel:
-  #   type: string
-  #   default:
-  # app-name:
-  #   type: string
   wait-for-rollout:
     type: boolean
     default: true
@@ -28,6 +18,9 @@ parameters:
   deployment-resource-name:
     default: deployment/app
     type: string
+  notification-channel:
+    type: string
+    default:
 
 steps:
   - checkout
@@ -95,3 +88,16 @@ steps:
 
   - steps: << parameters.post-deploy-steps >>
 
+
+  # Notify deploy, Using basic slack notification until a custom one can be created.
+  - when:
+      condition: << parameters.notification-channel >>
+      steps:
+        - slack/notify:
+            channel: << parameters.notification-channel >>
+            event: pass
+            template: basic_success_1
+        - slack/notify:
+            channel: << parameters.notification-channel >>
+            event: fail
+            template: basic_fail_1

--- a/src/commands/deploy-with-kustomize.yml
+++ b/src/commands/deploy-with-kustomize.yml
@@ -48,21 +48,6 @@ steps:
       install-kubectl: true
       aws-region: $AWS_REGION
 
-  # Deploy
-  # - run:
-  #     name: Deploy configuration to Kubernetes
-  #     command: ${HOME}/kube-apply.sh << parameters.kube-path >><< parameters.environment >> << parameters.app-name >>-<< parameters.environment >>
-
-  # # Conditionally wait for rollout to complete
-  # - when:
-  #     condition: << parameters.wait-for-rollout >>
-  #     steps:
-  #       - monitor-deployment:
-  #           maxAttempts: 30
-  #           kubernetesNamespace: << parameters.app-name >>-<< parameters.environment >>
-  #           kubernetesDeployment: << parameters.app-name >>-<< parameters.environment >>
-
-
   # Conditionally wait for rollout to complete
   - when:
       condition:

--- a/src/jobs/deploy-with-kustomize.yml
+++ b/src/jobs/deploy-with-kustomize.yml
@@ -39,19 +39,3 @@ steps:
       post-deploy-steps: << parameters.post-deploy-steps >>
       deployment-resource-name: << parameters.deployment-resource-name >>
       notification-channel: << parameters.notification-channel >>
-
-      # - goodway-deploy-with-kustomize:
-      #     name: deploy-staging
-      #     context:
-      #       - aws-oidc
-      #       - aws-ecr
-      #     cluster-name: goodway-staging
-      #     image-name: $AWS_ECR_REGISTRY_URL/microservice/test-vite
-      #     kustomize-path: .kube/overlays/staging
-      #     namespace: test-vite-staging
-      #     deployment-app-name: ui
-      #     requires:
-      #       - build
-      #     filters:
-      #       branches:
-      #         only: /^(main|release|hotfix|staging).*/

--- a/src/jobs/deploy-with-kustomize.yml
+++ b/src/jobs/deploy-with-kustomize.yml
@@ -20,6 +20,9 @@ parameters:
   deployment-resource-name:
     default: deployment/app
     type: string
+  notification-channel:
+    type: string
+    default:
 
 
 executor:
@@ -35,6 +38,7 @@ steps:
       wait-for-rollout: << parameters.wait-for-rollout >>
       post-deploy-steps: << parameters.post-deploy-steps >>
       deployment-resource-name: << parameters.deployment-resource-name >>
+      notification-channel: << parameters.notification-channel >>
 
       # - goodway-deploy-with-kustomize:
       #     name: deploy-staging

--- a/src/jobs/deploy-with-kustomize.yml
+++ b/src/jobs/deploy-with-kustomize.yml
@@ -1,0 +1,53 @@
+description: Deploy an image to kubernetes from build images hosted in ecr
+
+parameters:
+  environment:
+    type: string
+  app-name:
+    type: string
+  executor-tag:
+    type: string
+    default: '3.10'
+  kube-path:
+    type: string
+    default: .kube/
+  wait-for-rollout:
+    type: boolean
+    default: false
+  post-deploy-steps:
+    type: steps
+    default: []
+  deployment-resource-name:
+    default: deployment/app
+    type: string
+
+
+executor:
+  name: python-default
+  tag: << parameters.executor-tag >>
+
+steps:
+  - deploy-with-kustomize:
+      cluster-name: goodway-<< parameters.environment >>
+      image-name: $AWS_ECR_REGISTRY_URL/microservice/<< parameters.app-name >>
+      kustomize-path: << parameters.kube-path >>/overlays/<< parameters.environment >>
+      namespace: << parameters.app-name >>-<< parameters.environment >>
+      wait-for-rollout: << parameters.wait-for-rollout >>
+      post-deploy-steps: << parameters.post-deploy-steps >>
+      deployment-resource-name: << parameters.deployment-resource-name >>
+
+      # - goodway-deploy-with-kustomize:
+      #     name: deploy-staging
+      #     context:
+      #       - aws-oidc
+      #       - aws-ecr
+      #     cluster-name: goodway-staging
+      #     image-name: $AWS_ECR_REGISTRY_URL/microservice/test-vite
+      #     kustomize-path: .kube/overlays/staging
+      #     namespace: test-vite-staging
+      #     deployment-app-name: ui
+      #     requires:
+      #       - build
+      #     filters:
+      #       branches:
+      #         only: /^(main|release|hotfix|staging).*/


### PR DESCRIPTION
Adding new command and job that deploys our kubernetes files via kustomize.
It's almost a exact replacement for `goodway/deploy-to-kubernetes-ecr` and `goodway/deploy-to-kubernetes`

```
      ## STAGING
-      - goodway/deploy-to-kubernetes-ecr:
+      - goodway/deploy-with-kustomize:
           name: deploy-staging
-          context: aws-eks-goodway-staging-ecr
-          executor-tag: eks-latest
+          context:
+            - aws-oidc
+            - aws-ecr
+            - slack-notifications
            app-name: test-vite
            environment: staging
            notification-channel: notification-test
            post-deploy-steps:
              - goodway/notify-rollbar:
                  environment: staging
            requires:
              - build
            filters:
              branches:
                only: /^(main|release|hotfix|staging).*/
+          deployment-resource-name: deployment/ui
```
The major change, by design, is not to support docker hub images.  `deploy-with-kustomize` is expecting to deploy ECR images only


Also `deploy-with-kustomize` doesn't support custom executor and uses python-default.  A new parameters `deployment-resource-name` is here to support older project that have use 'ui' for deployment names.  The best practices going forward is to use `app` for all resource names.


Slack notifications are now using `circleci/slack@4.13.2` orb instead of our custom scripts which changes the notification a bit: https://goodwaygroup.slack.com/archives/C849DBQ7M/p1718605766529349

![2024-06-17_11-12-32](https://github.com/GoodwayGroup/circleci-orb/assets/22306490/a9c66b38-600a-4f04-bc08-ecfa5b5b2abe)

Testing See:  
- https://github.com/GoodwayGroup/test-vite/pull/2
- https://portal.staging.goodwaygroup.com/vite/

