### PR TITLE
chore: Adds optional package-lock-filename parameter to test-nodejs*

### DIFF
--- a/src/commands/test-nodejs.yml
+++ b/src/commands/test-nodejs.yml
@@ -11,6 +11,11 @@ parameters:
     type: steps
     default:
       - run: npm test
+  package-lock-filename:
+    type: string
+    default: package-lock.json
+    description: |
+      The package lock file to use for caching dependencies; npm should use package-lock.json, pnpm should use pnpm-lock.yaml, etc.
   lint:
     default: true
     description: |
@@ -49,14 +54,14 @@ steps:
   # Download and cache dependencies
   - restore_cache:
       keys:
-        - << parameters.cache-key >>-{{ checksum "package-lock.json" }}
+        - << parameters.cache-key >>-{{ checksum "<< parameters.package-lock-filename >>" }}
 
   - npm-install-or-ci
 
   - save_cache:
       paths:
         - node_modules
-      key: << parameters.cache-key >>-{{ checksum "package-lock.json" }}
+      key: << parameters.cache-key >>-{{ checksum "<< parameters.package-lock-filename >>" }}
 
   - when:
       condition: <<parameters.lint>>

--- a/src/commands/test-nodejs.yml
+++ b/src/commands/test-nodejs.yml
@@ -54,14 +54,14 @@ steps:
   # Download and cache dependencies
   - restore_cache:
       keys:
-        - << parameters.cache-key >>-{{ checksum "<< parameters.package-lock-filename >>" }}
+        - << parameters.cache-key >>-{{ checksum << parameters.package-lock-filename >> }}
 
   - npm-install-or-ci
 
   - save_cache:
       paths:
         - node_modules
-      key: << parameters.cache-key >>-{{ checksum "<< parameters.package-lock-filename >>" }}
+      key: << parameters.cache-key >>-{{ checksum << parameters.package-lock-filename >> }}
 
   - when:
       condition: <<parameters.lint>>

--- a/src/jobs/test-nodejs-ecr.yml
+++ b/src/jobs/test-nodejs-ecr.yml
@@ -29,6 +29,11 @@ parameters:
     type: steps
     default:
       - run: npm test
+  package-lock-filename:
+    type: string
+    default: package-lock.json
+    description: |
+      The package lock file to use for caching dependencies; npm should use package-lock.json, pnpm should use pnpm-lock.yaml, etc.
   lint:
     default: true
     description: |
@@ -71,3 +76,4 @@ steps:
       store-coverage-artifacts: << parameters.store-coverage-artifacts >>
       tar-coverage-artifacts: << parameters.tar-coverage-artifacts >>
       use-remote-docker: << parameters.use-remote-docker >>
+      package-lock-filename: << parameters.package-lock-filename >>

--- a/src/jobs/test-nodejs.yml
+++ b/src/jobs/test-nodejs.yml
@@ -30,6 +30,11 @@ parameters:
     type: steps
     default:
       - run: npm test
+  package-lock-filename:
+    type: string
+    default: package-lock.json
+    description: |
+      The package lock file to use for caching dependencies; npm should use package-lock.json, pnpm should use pnpm-lock.yaml, etc.
   lint:
     default: true
     description: |
@@ -72,3 +77,4 @@ steps:
       store-coverage-artifacts: << parameters.store-coverage-artifacts >>
       tar-coverage-artifacts: << parameters.tar-coverage-artifacts >>
       use-remote-docker: << parameters.use-remote-docker >>
+      package-lock-filename: << parameters.package-lock-filename >>


### PR DESCRIPTION
[SMS-1606](https://goodwaygroup.atlassian.net/browse/SMS-1606?atlOrigin=eyJpIjoiMDcyMTFhZTZjNGZmNDdlYzljZmI4MTc0OTQ1MzkwOGQiLCJwIjoiaiJ9)

We need to be able to specify the package-lock filename used as a cache key for CircleCI in order to use package managers like pnpm. [This PR](https://github.com/GoodwayGroup/goes/pull/13/files) in our goes repo adds this parameter. The current PR (yes, this one you're reading now) accomplishes that task.

There's a question in my mind about whether the parameter should be still surrounded by quotes. [This post](https://discuss.circleci.com/t/setting-cache-directory-for-save-cache-conditionally/49030/4) on discuss.circleci.com seems to suggest that doing so is correct. However, perplexity.ai makes a compelling case for leaving out the quotes:

```
Based on the information you've provided, when parameterizing the filename in a CircleCI orb file command,
you should not wrap the parameter in quotes. The correct way to use the parameter in this context is:
Here's why:
CircleCI uses double curly braces {{ }} for variable substitution and command execution.
The << >> syntax is used for parameter substitution in orbs.
The checksum function is expecting a string argument, but the parameter substitution will provide that string.
By using this format, CircleCI will:
First, substitute the parameter value for << parameters.package-lock-filename >>.
Then, execute the checksum function on the resulting filename.
```

[SMS-1606]: https://goodwaygroup.atlassian.net/browse/SMS-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# Testing
This workflow seems to let one validate the pattern locally:
```
❯ circleci orb pack src/ > orbtest.yml
❯ circleci orb validate ./orbtest.yml
Orb at `./orbtest.yml` is valid.
❯ cat orbtest.yml | grep package-lock-filename
            package-lock-filename:
                    - << parameters.cache-key >>-{{ checksum << parameters.package-lock-filename >> }}
                key: << parameters.cache-key >>-{{ checksum << parameters.package-lock-filename >> }}
            package-lock-filename:
                package-lock-filename: << parameters.package-lock-filename >>
            package-lock-filename:
                package-lock-filename: << parameters.package-lock-filename >>
```

# Callouts
I did NOT add the parameter to the apollo-service-task step as AFAIK, we don't have plans to add pnpm to any apollo projects and I wanted to minimize the surface area in case this change broke something.