### PR TITLE
fix: Adds quotes around parameter in mustache braces

### DIFF
--- a/src/commands/test-nodejs.yml
+++ b/src/commands/test-nodejs.yml
@@ -54,14 +54,14 @@ steps:
   # Download and cache dependencies
   - restore_cache:
       keys:
-        - << parameters.cache-key >>-{{ checksum << parameters.package-lock-filename >> }}
+        - << parameters.cache-key >>-{{ checksum "<< parameters.package-lock-filename >>" }}
 
   - npm-install-or-ci
 
   - save_cache:
       paths:
         - node_modules
-      key: << parameters.cache-key >>-{{ checksum << parameters.package-lock-filename >> }}
+      key: << parameters.cache-key >>-{{ checksum "<< parameters.package-lock-filename >>" }}
 
   - when:
       condition: <<parameters.lint>>


### PR DESCRIPTION
The previous pattern of NOT quoting parameters following the checksum command errors when deploying applications using that orb:
![Screenshot 2024-08-23 at 9 56 03 AM](https://github.com/user-attachments/assets/a832764d-ca39-4d48-903f-3bb941132203)

However, adding the quotes in seems to get the filename through to the checksum command correctly (however, it looks like it's failing for a different reason in the `goes` repo).
![Screenshot 2024-08-23 at 9 59 13 AM](https://github.com/user-attachments/assets/3cf54f6b-2111-408d-8e39-a08860689639)
