### PR TITLE
fix: replaced deprecated deploy step with run

### DIFF
--- a/src/commands/push-with-dynamic-tag.yml
+++ b/src/commands/push-with-dynamic-tag.yml
@@ -17,7 +17,7 @@ parameters:
     description: 'Image tag environment variable, defaults to CIRCLE_SHA1'
     type: env_var_name
 steps:
-  - deploy:
+  - run:
       command: >
         docker push <<parameters.registry>>/<<
         parameters.image>> --all-tags


### PR DESCRIPTION
Replaced deprecated deploy step with run. See https://circleci.com/docs/migrate-from-deploy-to-run/ for more info
