### PR TITLE
chore: ENG-741 deprecated coveralls-upload and defaulting false

### DIFF
--- a/src/commands/docker-build.yml
+++ b/src/commands/docker-build.yml
@@ -4,7 +4,7 @@ parameters:
   registry-type:
     type: enum
     default: dockerhub
-    enum: ["dockerhub", "ecr"]
+    enum: ['dockerhub', 'ecr']
   registry-url:
     type: env_var_name
     default: DOCKER_REGISTRY
@@ -23,6 +23,9 @@ parameters:
   pre-push-steps:
     type: steps
     default: []
+  post-push-steps:
+    type: steps
+    default: []
   use-docker-layer-caching:
     type: boolean
     default: true
@@ -31,7 +34,7 @@ parameters:
     type: string
   additional-tags:
     type: string
-    default: ""
+    default: ''
     description: Space separated names for additional images tags.
 
 steps:
@@ -41,7 +44,7 @@ steps:
 
   - when:
       condition:
-        equal: ["ecr", << parameters.registry-type >>]
+        equal: ['ecr', << parameters.registry-type >>]
       steps:
         - aws-ecr/ecr-login:
             account-url: << parameters.registry-url >>
@@ -49,7 +52,7 @@ steps:
 
   - when:
       condition:
-        equal: ["dockerhub", << parameters.registry-type >>]
+        equal: ['dockerhub', << parameters.registry-type >>]
       steps:
         - docker/check:
             docker-password: DOCKER_PASS
@@ -84,3 +87,4 @@ steps:
             image: ${<< parameters.image-namespace >>}/${<< parameters.image-repo >>}
             tag-env: DOCKER_TAG
             registry: ${<< parameters.registry-url >>}
+        - steps: << parameters.post-push-steps >>

--- a/src/commands/test-nodejs.yml
+++ b/src/commands/test-nodejs.yml
@@ -6,7 +6,7 @@ parameters:
     default: v0-dependencies
   coveralls-upload:
     type: boolean
-    default: true
+    default: false # coveralls is no longer supported
   test-steps:
     type: steps
     default:

--- a/src/commands/test-python.yml
+++ b/src/commands/test-python.yml
@@ -6,7 +6,7 @@ parameters:
     default: v0-dependencies
   coveralls-upload:
     type: boolean
-    default: true
+    default: false # coveralls is no longer supported
   coveralls-steps:
     default:
       - run:

--- a/src/jobs/deploy-with-kustomize.yml
+++ b/src/jobs/deploy-with-kustomize.yml
@@ -37,7 +37,7 @@ parameters:
     default:
   cluster-name:
     type: string
-    default:
+    default: ''
 
 executor:
   name: python-default

--- a/src/jobs/deploy-with-kustomize.yml
+++ b/src/jobs/deploy-with-kustomize.yml
@@ -8,6 +8,18 @@ parameters:
   executor-tag:
     type: string
     default: '3.10'
+  executor-resource-class:
+    default: small
+    description: Configure the executor resource class
+    enum:
+      - small
+      - medium
+      - medium+
+      - large
+      - xlarge
+      - 2xlarge
+      - 2xlarge+
+    type: enum
   kube-path:
     type: string
     default: .kube/
@@ -30,9 +42,9 @@ parameters:
 executor:
   name: python-default
   tag: << parameters.executor-tag >>
+  resource_class: << parameters.executor-resource-class >>
 
 steps:
-
   - unless:
       condition: << parameters.cluster-name >>
       steps:
@@ -57,4 +69,3 @@ steps:
             post-deploy-steps: << parameters.post-deploy-steps >>
             deployment-resource-name: << parameters.deployment-resource-name >>
             notification-channel: << parameters.notification-channel >>
-

--- a/src/jobs/docker-build-ecr.yml
+++ b/src/jobs/docker-build-ecr.yml
@@ -3,13 +3,13 @@ description: Docker image build and push from build images hosted in ecr
 parameters:
   executor-name:
     type: enum
-    default: "ecr-authed"
-    enum: ["build-images", "dockerhub-authed", "ecr-authed"]
+    default: 'node-default'
+    enum: ['build-images', 'dockerhub-authed', 'ecr-authed', 'node-default']
   executor-tag:
     type: string
-    default: node-latest
+    default: lts
   executor-resource-class:
-    default: medium
+    default: small
     description: Configure the executor resource class
     enum:
       - small
@@ -23,7 +23,7 @@ parameters:
   registry-type:
     type: enum
     default: ecr
-    enum: ["dockerhub", "ecr"]
+    enum: ['dockerhub', 'ecr']
   registry-url:
     type: env_var_name
     default: DOCKER_REGISTRY
@@ -42,6 +42,9 @@ parameters:
   pre-push-steps:
     type: steps
     default: []
+  post-push-steps:
+    type: steps
+    default: []
   use-docker-layer-caching:
     type: boolean
     default: true
@@ -50,7 +53,7 @@ parameters:
     type: string
   additional-tags:
     type: string
-    default: ""
+    default: ''
 
 executor:
   name: << parameters.executor-name >>
@@ -69,3 +72,4 @@ steps:
       use-docker-layer-caching: << parameters.use-docker-layer-caching >>
       extra-build-args: << parameters.extra-build-args >>
       additional-tags: << parameters.additional-tags >>
+      post-push-steps: << parameters.post-push-steps >>

--- a/src/jobs/docker-build.yml
+++ b/src/jobs/docker-build.yml
@@ -3,11 +3,11 @@ description: Docker image build and push
 parameters:
   executor-name:
     type: enum
-    default: "build-images"
-    enum: ["build-images", "dockerhub-authed", "ecr-authed"]
+    default: 'node-default'
+    enum: ['build-images', 'dockerhub-authed', 'ecr-authed', 'node-default']
   executor-tag:
     type: string
-    default: node-12
+    default: lts
   executor-resource-class:
     default: medium
     description: Configure the executor resource class
@@ -23,7 +23,7 @@ parameters:
   registry-type:
     type: enum
     default: dockerhub
-    enum: ["dockerhub", "ecr"]
+    enum: ['dockerhub', 'ecr']
   registry-url:
     type: env_var_name
     default: DOCKER_REGISTRY
@@ -42,6 +42,9 @@ parameters:
   pre-push-steps:
     type: steps
     default: []
+  post-push-steps:
+    type: steps
+    default: []
   use-docker-layer-caching:
     type: boolean
     default: true
@@ -50,7 +53,7 @@ parameters:
     type: string
   additional-tags:
     type: string
-    default: ""
+    default: ''
     description: Space separated names for additional images tags.
 
 executor:
@@ -70,3 +73,4 @@ steps:
       use-docker-layer-caching: << parameters.use-docker-layer-caching >>
       extra-build-args: << parameters.extra-build-args >>
       additional-tags: << parameters.additional-tags >>
+      post-push-steps: << parameters.post-push-steps >>

--- a/src/jobs/test-nodejs-ecr.yml
+++ b/src/jobs/test-nodejs-ecr.yml
@@ -3,8 +3,8 @@ description: Install dependencies and run test command from build images hosted 
 parameters:
   executor-name:
     type: enum
-    default: "ecr-authed"
-    enum: ["build-images", "dockerhub-authed", "ecr-authed", "node-default"]
+    default: 'ecr-authed'
+    enum: ['build-images', 'dockerhub-authed', 'ecr-authed', 'node-default']
   executor-tag:
     type: string
   executor-resource-class:
@@ -24,7 +24,7 @@ parameters:
     default: v0-dependencies
   coveralls-upload:
     type: boolean
-    default: true
+    default: false # coveralls is no longer supported
   test-steps:
     type: steps
     default:

--- a/src/jobs/test-nodejs.yml
+++ b/src/jobs/test-nodejs.yml
@@ -3,8 +3,8 @@ description: Install dependencies and run test command
 parameters:
   executor-name:
     type: enum
-    default: "build-images"
-    enum: ["build-images", "dockerhub-authed", "ecr-authed", "node-default"]
+    default: 'build-images'
+    enum: ['build-images', 'dockerhub-authed', 'ecr-authed', 'node-default']
   executor-tag:
     type: string
     default: node-12
@@ -25,7 +25,7 @@ parameters:
     default: v0-dependencies
   coveralls-upload:
     type: boolean
-    default: true
+    default: false # coveralls is no longer supported
   test-steps:
     type: steps
     default:

--- a/src/jobs/test-python-dsa.yml
+++ b/src/jobs/test-python-dsa.yml
@@ -3,7 +3,7 @@ description: Install dependencies and run test command
 parameters:
   executor-tag:
     type: string
-    default: "3.11.2"
+    default: '3.11.2'
   executor-resource-class:
     default: large
     description: Configure the executor resource class
@@ -21,7 +21,7 @@ parameters:
     default: v0-dependencies
   coveralls-upload:
     type: boolean
-    default: true
+    default: false # coveralls is no longer supported
   coveralls-steps:
     default:
       - run:
@@ -76,7 +76,7 @@ steps:
   - test-python:
       cache-key: << parameters.cache-key >>
       coveralls-upload: << parameters.coveralls-upload >>
-      coveralls-steps:  << parameters.coveralls-steps >>
+      coveralls-steps: << parameters.coveralls-steps >>
       test-steps: << parameters.test-steps >>
       lint: << parameters.lint >>
       lint-steps: << parameters.lint-steps >>

--- a/src/jobs/test-python.yml
+++ b/src/jobs/test-python.yml
@@ -3,7 +3,7 @@ description: Install dependencies and run test command
 parameters:
   executor-tag:
     type: string
-    default: "3.7"
+    default: '3.7'
   executor-resource-class:
     default: large
     description: Configure the executor resource class
@@ -21,7 +21,7 @@ parameters:
     default: v0-dependencies
   coveralls-upload:
     type: boolean
-    default: true
+    default: false # coveralls is no longer supported
   coveralls-steps:
     default:
       - run:
@@ -76,7 +76,7 @@ steps:
   - test-python:
       cache-key: << parameters.cache-key >>
       coveralls-upload: << parameters.coveralls-upload >>
-      coveralls-steps:  << parameters.coveralls-steps >>
+      coveralls-steps: << parameters.coveralls-steps >>
       test-steps: << parameters.test-steps >>
       lint: << parameters.lint >>
       lint-steps: << parameters.lint-steps >>


### PR DESCRIPTION
## SUMMARY

1. fix: cluster-name param default value
2. feat: adding resource-class param to deploy-with-kustomize
3. feat: defaulting docker-build to use cim/node as executor
4. chore: deprecated coveralls-upload and defaulting false

## TESTING
See these two PRs using the dev release version:

https://github.com/GoodwayGroup/service-email/pull/157
https://github.com/GoodwayGroup/streamlit-ds-simple-scenario-modeler/pull/29


## STORY NUMBER and LINK
[ENG-741](https://goodwaygroup.atlassian.net/browse/ENG-741)

## CRITICAL REVIEW AREAS
N/A


[ENG-741]: https://goodwaygroup.atlassian.net/browse/ENG-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ